### PR TITLE
chore: allow string or number amount in format price

### DIFF
--- a/src/currency/index.spec.ts
+++ b/src/currency/index.spec.ts
@@ -3,50 +3,64 @@ import { formatPrice } from './index';
 import type { Currency } from './index';
 
 describe('formatPrice', () => {
+  test('should format price in the same way with a numeric or string amount', () => {
+    const moneyString = {
+      amount: '1234.56',
+      currencyCode: 'EUR',
+    } satisfies Currency;
+    const moneyNumber = {
+      amount: 1234.56,
+      currencyCode: 'EUR',
+    } satisfies Currency;
+    const resultString = formatPrice(moneyString);
+    const resultNumber = formatPrice(moneyNumber);
+
+    expect(resultString).toBe(resultNumber);
+  });
   test('should format price with default locale and cents enabled', () => {
-    const money = { amount: '1234.56', currencyCode: 'EUR' } satisfies Currency;
+    const money = { amount: 1234.56, currencyCode: 'EUR' } satisfies Currency;
     const result = formatPrice(money);
 
     expect(result).toBe('1 234,56 €');
   });
 
   test('should format price with custom locale and cents enabled', () => {
-    const money = { amount: '1234.56', currencyCode: 'USD' } satisfies Currency;
+    const money = { amount: 1234.56, currencyCode: 'USD' } satisfies Currency;
     const result = formatPrice(money, 'en-US');
 
     expect(result).toBe('$1,234.56');
   });
 
   test('should format price with quantity multiplier', () => {
-    const money = { amount: '1234.56', currencyCode: 'USD' } satisfies Currency;
+    const money = { amount: 1234.56, currencyCode: 'USD' } satisfies Currency;
     const result = formatPrice(money, 'en-US', 2);
 
     expect(result).toBe('$2,469.12');
   });
 
   test('should format price with cents disabled when applicable', () => {
-    const money = { amount: '1234.00', currencyCode: 'USD' } satisfies Currency;
+    const money = { amount: 1234, currencyCode: 'USD' } satisfies Currency;
     const result = formatPrice(money, 'en-US', 1, true);
 
     expect(result).toBe('$1,234');
   });
 
   test('should still include cents if the amount has fractional part even if disableCents is true', () => {
-    const money = { amount: '1234.56', currencyCode: 'USD' } satisfies Currency;
+    const money = { amount: 1234.56, currencyCode: 'USD' } satisfies Currency;
     const result = formatPrice(money, 'en-US', 1, true);
 
     expect(result).toBe('$1,234.56');
   });
 
   test('should format price correctly with a different currency code', () => {
-    const money = { amount: '1234.56', currencyCode: 'GBP' } satisfies Currency;
+    const money = { amount: 1234.56, currencyCode: 'GBP' } satisfies Currency;
     const result = formatPrice(money, 'en-GB');
 
     expect(result).toBe('£1,234.56');
   });
 
   test('should handle large quantities correctly', () => {
-    const money = { amount: '1000.00', currencyCode: 'EUR' } satisfies Currency;
+    const money = { amount: 1000, currencyCode: 'EUR' } satisfies Currency;
     const result = formatPrice(money, 'fr', 100);
 
     expect(result).toBe('100 000,00 €');

--- a/src/currency/index.ts
+++ b/src/currency/index.ts
@@ -1,7 +1,7 @@
 import type { CurrencyCode } from './types';
 
 export type Currency = {
-  amount: string;
+  amount: string | number;
   currencyCode: CurrencyCode;
 };
 
@@ -11,7 +11,7 @@ export const formatPrice = (
   quantity = 1,
   disableCents = false,
 ): string => {
-  const price = Number.parseFloat(amount);
+  const price = typeof amount === 'number' ? amount : Number.parseFloat(amount);
 
   return new Intl.NumberFormat(locale, {
     style: 'currency',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Price formatting now accepts amounts provided as numbers in addition to strings, with consistent output across locales, currencies, quantity scaling, and cents-handling options.

* **Tests**
  * Added tests to verify identical results when amounts are provided as strings vs. numbers.
  * Updated existing test cases to use numeric amounts across scenarios (default/custom locale, quantity multipliers, cents disabled, fractional retention, different currencies, large quantities).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->